### PR TITLE
Use implicit param `?callStack` when HUnit >= 1.4.0.0 (fixes #3)

### DIFF
--- a/src/Test/Hspec/Expectations/Pretty.hs
+++ b/src/Test/Hspec/Expectations/Pretty.hs
@@ -68,7 +68,13 @@ import           Control.Monad (unless)
 
 import           Test.Hspec.Expectations.Pretty.Matcher
 
-#ifdef HAS_SOURCE_LOCATIONS
+#if defined(HAS_SOURCE_LOCATIONS) && MIN_VERSION_HUnit(1,4,0)
+
+import           GHC.Stack
+
+#define with_loc(NAME, TYPE) NAME :: (?callStack :: CallStack) => TYPE
+
+#elif defined(HAS_SOURCE_LOCATIONS)
 
 import           GHC.Stack
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
 flags: {}
 packages:
   - '.'
-resolver: lts-5.9
+resolver: lts-14.2
 extra-deps:
-  - HUnit-1.3.0.0
   - nicify-lib-1.0.1


### PR DESCRIPTION
Bumped stackage snapshot to lts-14.2