### PR TITLE
added: unicode-show

### DIFF
--- a/hspec-expectations-pretty-diff.cabal
+++ b/hspec-expectations-pretty-diff.cabal
@@ -29,6 +29,7 @@ library
     , hscolour
     , Diff
     , ansi-terminal
+    , unicode-show
   exposed-modules:
       Test.Hspec.Expectations.Pretty
       Test.Hspec.Expectations.Pretty.Contrib

--- a/src/Test/Hspec/Expectations/Pretty.hs
+++ b/src/Test/Hspec/Expectations/Pretty.hs
@@ -56,6 +56,7 @@ import qualified Test.HUnit
 import           Control.Exception
 import           Data.Typeable
 import           Data.List
+import           Text.Show.Unicode (ushow)
 #if MIN_VERSION_Diff(0,4,0)
 import           Data.Algorithm.Diff (getDiff, PolyDiff(First, Second, Both))
 #else
@@ -102,7 +103,7 @@ infix 1 `shouldBe`, `shouldSatisfy`, `shouldStartWith`, `shouldEndWith`, `should
 infix 1 `shouldNotBe`, `shouldNotSatisfy`, `shouldNotContain`, `shouldNotReturn`
 
 prettyColor :: Show a => a -> String
-prettyColor = hscolour' . nicify . show
+prettyColor = hscolour' . nicify . ushow
   where hscolour' = hscolour (TTYg Ansi16Colour) defaultColourPrefs False False "" False
 
 diffColor :: String -> String -> String
@@ -121,12 +122,12 @@ actual `shouldBe` expected = expectTrue (diffColor (prettyColor expected) (prett
 -- |
 -- @v \`shouldSatisfy\` p@ sets the expectation that @p v@ is @True@.
 with_loc(shouldSatisfy, (Show a) => a -> (a -> Bool) -> Expectation)
-v `shouldSatisfy` p = expectTrue ("predicate failed on: " ++ show v) (p v)
+v `shouldSatisfy` p = expectTrue ("predicate failed on: " ++ ushow v) (p v)
 
 with_loc(compareWith, (Show a, Eq a) => (a -> a -> Bool) -> String -> a -> a -> Expectation)
 compareWith comparator errorDesc result expected = expectTrue errorMsg (comparator expected result)
   where
-    errorMsg = show result ++ " " ++ errorDesc ++ " " ++ show expected
+    errorMsg = ushow result ++ " " ++ errorDesc ++ " " ++ ushow expected
 
 -- |
 -- @list \`shouldStartWith\` prefix@ sets the expectation that @list@ starts with @prefix@,
@@ -160,12 +161,12 @@ action `shouldReturn` expected = action >>= (`shouldBe` expected)
 -- @actual \`shouldNotBe\` notExpected@ sets the expectation that @actual@ is not
 -- equal to @notExpected@
 with_loc(shouldNotBe, (Show a, Eq a) => a -> a -> Expectation)
-actual `shouldNotBe` notExpected = expectTrue ("not expected: " ++ show actual) (actual /= notExpected)
+actual `shouldNotBe` notExpected = expectTrue ("not expected: " ++ ushow actual) (actual /= notExpected)
 
 -- |
 -- @v \`shouldNotSatisfy\` p@ sets the expectation that @p v@ is @False@.
 with_loc(shouldNotSatisfy, (Show a) => a -> (a -> Bool) -> Expectation)
-v `shouldNotSatisfy` p = expectTrue ("predicate succeded on: " ++ show v) ((not . p) v)
+v `shouldNotSatisfy` p = expectTrue ("predicate succeded on: " ++ ushow v) ((not . p) v)
 
 -- |
 -- @list \`shouldNotContain\` sublist@ sets the expectation that @sublist@ is not
@@ -173,7 +174,7 @@ v `shouldNotSatisfy` p = expectTrue ("predicate succeded on: " ++ show v) ((not 
 with_loc(shouldNotContain, (Show a, Eq a) => [a] -> [a] -> Expectation)
 list `shouldNotContain` sublist = expectTrue errorMsg ((not . isInfixOf sublist) list)
   where
-    errorMsg = show list ++ " does contain " ++ show sublist
+    errorMsg = ushow list ++ " does contain " ++ ushow sublist
 
 -- |
 -- @action \`shouldNotReturn\` notExpected@ sets the expectation that @action@
@@ -199,10 +200,10 @@ action `shouldThrow` p = do
         "did not get expected exception: " ++ exceptionType
     Left e ->
       (`expectTrue` p e) $
-        "predicate failed on expected exception: " ++ exceptionType ++ " (" ++ show e ++ ")"
+        "predicate failed on expected exception: " ++ exceptionType ++ " (" ++ ushow e ++ ")"
   where
     -- a string repsentation of the expected exception's type
-    exceptionType = (show . typeOf . instanceOf) p
+    exceptionType = (ushow . typeOf . instanceOf) p
       where
         instanceOf :: Selector a -> a
         instanceOf _ = error "Test.Hspec.Expectations.shouldThrow: broken Typeable instance"


### PR DESCRIPTION
I very much wanted to use this package that makes hspec diffs dramatically easier to understand, but there was one problem.
I am a Japanese user, and my program also handles Japanese.
There is an unfortunate specification in Haskell's show as follows.
ref: [If you show Japanese and it doesn't show up well - Haskell-jp](https://haskell.jp/blog/posts/2019/unicode-show.html)
This is also true in the original hspec, but hspec-expectations-pretty-diff accelerates the problem.
In hspec, `"犬"` is output as `"\29356"` with a backslash, so we know that some escaping has taken place, but hspec-expectations-pretty-diff removes the backslash and prints "29356", so the numeric string The hspec-expectations-pretty-diff removes the backslash and displays "29356", which accelerates the risk of mistakenly thinking there is a string of numbers.
Therefore, I added unicode-show and replaced the internal show with ushow.

Translated with www.DeepL.com/Translator (free version)